### PR TITLE
Add platform check to PostBuild.cs

### DIFF
--- a/Assets/Plugins/Appboy/Editor/PostBuild.cs
+++ b/Assets/Plugins/Appboy/Editor/PostBuild.cs
@@ -1,10 +1,12 @@
-﻿using System;
+#if UNITY_IOS
+using System;
 using System.IO;
 using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEditor.iOS.Xcode;
+#endif
 
 namespace Appboy.Editor {
   public class PostBuild {


### PR DESCRIPTION
Guard against missing dependency error when Unity iOS build support is not installed