### PR TITLE
Fix code attempting to set an enum to null in Card.cs

### DIFF
--- a/Assets/Plugins/Appboy/models/Cards/Card.cs
+++ b/Assets/Plugins/Appboy/models/Cards/Card.cs
@@ -47,10 +47,13 @@ namespace Appboy.Models.Cards {
           Categories.Add(CardCategory.NO_CATEGORY);
         } else {
           for (int i = 0; i < jsonArray.Count; i++) {
-            CardCategory category = (CardCategory)EnumUtils.TryParse(typeof(CardCategory), jsonArray[i], true, null);
-            if (category != null) {
+            CardCategory category = (CardCategory)EnumUtils.TryParse(typeof(CardCategory), jsonArray[i], true, CardCategory.NO_CATEGORY);
+            if (category != CardCategory.NO_CATEGORY) {
               Categories.Add(category);
             }
+          }
+          if (Categories.Count == 0) {
+            Categories.Add(CardCategory.NO_CATEGORY);
           }
         }
       }


### PR DESCRIPTION
We noticed a bug in Card.cs where it is trying to set the default value of an enum to null, and then doing a null check on the enum. This doesn't work, and generates a warning. I think I have achieved the desired behavior in this patch, where invalid enum values in the JSON will not be added to the Categories HashSet, but if there are no valid categories it will add NO_CATEGORY.