### PR TITLE
iOS Automate Endpoint config

### DIFF
--- a/Assets/Plugins/Appboy/Editor/AppboyConfig.cs
+++ b/Assets/Plugins/Appboy/Editor/AppboyConfig.cs
@@ -20,6 +20,10 @@ namespace Appboy.Editor {
     // App Startup
     [SerializeField]
     private string apiKey = string.Empty;
+    [SerializeField]
+    private string endpoint = string.Empty;
+    [SerializeField]
+    private string logLevel = string.Empty;
 
     // Push Notifications
     [SerializeField]
@@ -36,7 +40,7 @@ namespace Appboy.Editor {
     private string iOSPushOpenedGameObjectName = string.Empty;
     [SerializeField]
     private string iOSPushOpenedCallbackMethodName = string.Empty;
-    
+
     // In-App Messages
     [SerializeField]
     private string iOSInAppMessageGameObjectName = string.Empty;
@@ -67,12 +71,22 @@ namespace Appboy.Editor {
       set { SetProperty(ref Instance.apiKey, value); }
     }
 
+    public static string Endpoint {
+        get { return Instance.endpoint; }
+        set { SetProperty(ref Instance.endpoint, value); }
+    }
+
+    public static string LogLevel {
+        get { return Instance.logLevel; }
+        set { SetProperty(ref Instance.logLevel, value); }
+    }
+
     // Push
     public static bool IOSIntegratesPush {
       get { return Instance.iOSIntegratesPush; }
       set { SetProperty(ref Instance.iOSIntegratesPush, value); }
     }
-    
+
     public static bool IOSDisableAutomaticPushRegistration {
       get { return Instance.iOSDisableAutomaticPushRegistration; }
       set { SetProperty(ref Instance.iOSDisableAutomaticPushRegistration, value); }
@@ -108,7 +122,7 @@ namespace Appboy.Editor {
       get { return Instance.iOSInAppMessageGameObjectName; }
       set { SetProperty(ref Instance.iOSInAppMessageGameObjectName, value); }
     }
-    
+
     public static string IOSInAppMessageCallbackMethodName {
       get { return Instance.iOSInAppMessageCallbackMethodName; }
       set { SetProperty(ref Instance.iOSInAppMessageCallbackMethodName, value); }

--- a/Assets/Plugins/Appboy/Editor/AppboyConfigEditor.cs
+++ b/Assets/Plugins/Appboy/Editor/AppboyConfigEditor.cs
@@ -26,9 +26,17 @@ namespace Appboy.Editor {
     }
 
     private void ApiKeyGUI() {
-      EditorGUILayout.BeginVertical();
-      AppboyConfig.ApiKey = EditorGUILayout.TextField("Braze API Key", AppboyConfig.ApiKey);
-      EditorGUILayout.EndVertical();
+        AppboyConfig.ApiKey = EditorGUILayout.TextField("Braze API Key", AppboyConfig.ApiKey);
+    }
+
+    private void EndpointGUI() {
+        AppboyConfig.Endpoint = EditorGUILayout.TextField("Braze SDK Endpoint", AppboyConfig.Endpoint);
+        EditorGUILayout.LabelField("If you are on the default Braze SDK Endpoint, you can leave this blank.", EditorStyles.wordWrappedMiniLabel);
+    }
+
+    private void LogLevelGUI() {
+        AppboyConfig.LogLevel = EditorGUILayout.TextField("SDK Log Level", AppboyConfig.LogLevel);
+        EditorGUILayout.LabelField("Leaving this blank will use the default log level, setting it to \"0\" will enable verbose logging.", EditorStyles.wordWrappedMiniLabel);
     }
 
     private void IOSBuildGUI() {
@@ -38,8 +46,11 @@ namespace Appboy.Editor {
       if (AppboyConfig.IOSAutomatesIntegration) {
         EditorGUI.indentLevel++;
 
-        // API Key
+        // API Key and Endpoint
+        EditorGUILayout.BeginVertical();
         ApiKeyGUI();
+        EndpointGUI();
+        EditorGUILayout.EndVertical();
         EditorGUILayout.Separator();
 
         // Push Notifications
@@ -117,6 +128,14 @@ namespace Appboy.Editor {
           AppboyConfig.IOSContentCardsCallbackMethodName = EditorGUILayout.TextField("Callback Method Name", AppboyConfig.IOSContentCardsCallbackMethodName);
           EditorGUI.indentLevel--;
         }
+        EditorGUI.indentLevel--;
+        EditorGUILayout.Separator();
+
+        // SDK Debugging
+        EditorGUILayout.LabelField("SDK Debugging", EditorStyles.boldLabel);
+        EditorGUI.indentLevel++;
+        LogLevelGUI();
+
         EditorGUI.indentLevel--;
         EditorGUILayout.EndVertical();
       }

--- a/Assets/Plugins/Appboy/Editor/PostBuild.cs
+++ b/Assets/Plugins/Appboy/Editor/PostBuild.cs
@@ -16,6 +16,8 @@ namespace Appboy.Editor {
     private const string AppboyAppDelegatePath = "Libraries/Plugins/iOS/AppboyAppDelegate.mm";
     private const string PlistSubpath = "/Info.plist";
 
+    private const string ABKEndpointKey = "Endpoint";
+    private const string ABKLogLevelKey = "LogLevel";
     private const string ABKUnityApiKey = "ApiKey";
     private const string ABKUnityAutomaticPushIntegrationKey = "IntegratesPush";
     private const string ABKUnityDisableAutomaticPushRegistrationKey = "DisableAutomaticPushRegistration";
@@ -127,8 +129,24 @@ namespace Appboy.Editor {
 
       // Add Appboy Unity keys to Plist
       if (AppboyConfig.IOSAutomatesIntegration) {
+        // The Appboy dictionary
+        PlistElementDict appboyDict = (rootDict["Appboy"] == null) ? rootDict.CreateDict("Appboy") : rootDict["Appboy"].AsDict();
         // The Appboy Unity dictionary
-        PlistElementDict appboyUnityDict = (rootDict["Appboy"] == null) ? rootDict.CreateDict("Appboy").CreateDict("Unity") : rootDict["Appboy"].AsDict().CreateDict("Unity");
+        PlistElementDict appboyUnityDict = appboyDict.CreateDict("Unity");
+
+        // Add iOS SDK keys to Plist
+        if (string.IsNullOrEmpty(AppboyConfig.Endpoint.Trim())) {
+            appboyDict.values.Remove(ABKEndpointKey);
+        }
+        else {
+            appboyDict.SetString(ABKEndpointKey, AppboyConfig.Endpoint.Trim());
+        }
+        if (string.IsNullOrEmpty(AppboyConfig.LogLevel.Trim())) {
+            appboyDict.values.Remove(ABKLogLevelKey);
+        }
+        else {
+            appboyDict.SetString(ABKLogLevelKey, AppboyConfig.LogLevel.Trim());
+        }
 
         // Add iOS automated integration build keys to Plist
         if (ValidateField(ABKUnityApiKey, AppboyConfig.ApiKey, "Appboy will not be initialized.")) {


### PR DESCRIPTION
This adds support for configuring the SDK Endpoint for iOS Automated Integration, which is a required step if you are not on the default Endpoint. It also adds support for configuring the SDK LogLevel, which is useful for debugging.