### PR TITLE
Add asmdef files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ UnityPackageManager/
 /Packages
 /Temp
 /Library
+/UserSettings
 ## https://stackoverflow.com/a/57728803/3745724
 
 # Firebase
@@ -30,6 +31,7 @@ UnityPackageManager/
 /unity-package
 /Assets/Resources*
 /Assembly*csproj
+/Appboy*csproj
 /*sln
 
 # Scripts

--- a/Assets/Plugins/Appboy/Appboy.asmdef
+++ b/Assets/Plugins/Appboy/Appboy.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Appboy",
+    "rootNamespace": "Appboy",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Plugins/Appboy/Appboy.asmdef.meta
+++ b/Assets/Plugins/Appboy/Appboy.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 04daa7abf8c09a14b88cac8335a5991f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Appboy/Editor/Appboy.Editor.asmdef
+++ b/Assets/Plugins/Appboy/Editor/Appboy.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Appboy.Editor",
+    "rootNamespace": "Appboy.Editor",
+    "references": [
+        "GUID:04daa7abf8c09a14b88cac8335a5991f"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Plugins/Appboy/Editor/Appboy.Editor.asmdef.meta
+++ b/Assets/Plugins/Appboy/Editor/Appboy.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3741a048b6e841942a548370758d5b36
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Created two asmdef files:

1. `Assets/Plugins/Appboy/Appboy.asmdef` 
    - For runtime code. 
    - Set for all platforms.
    - Has the root namespace of `Appboy`.
2. `Assets/Plugins/Appboy/Editor/Appboy.Editor.asmdef` 
    - For editor code.
    - Set for editor platform only.
    - Has the root namespace of `Appboy.Editor`.
    - References `Appboy.asmdef`.

Both `asmdef` files have `Auto Referenced` option enabled, so users don't need `asmdef`s to consume the code.

All in all, nothing should change for users that don't utilize `asmdef` files themselves, while making things extremely easier for users that do utilize `asmdef` files (such as UPM package developers).

Unity docs on `asmdef` options: https://docs.unity3d.com/Manual/class-AssemblyDefinitionImporter.html

Closes #52 